### PR TITLE
Added wait_for_job_completion call to fix bug for clear_foreign_config via ironic cli

### DIFF
--- a/ironic/drivers/modules/drac/job.py
+++ b/ironic/drivers/modules/drac/job.py
@@ -15,6 +15,9 @@
 DRAC Lifecycle job specific methods
 """
 
+
+from time import sleep
+
 from oslo_log import log as logging
 from oslo_utils import importutils
 
@@ -80,3 +83,8 @@ def list_unfinished_jobs(node):
                   {'node_uuid': node.uuid,
                    'error': exc})
         raise exception.DracOperationError(error=exc)
+
+
+def wait_for_job_completion(node):
+    while list_unfinished_jobs(node):
+        sleep(10)

--- a/ironic/drivers/modules/drac/raid.py
+++ b/ironic/drivers/modules/drac/raid.py
@@ -278,7 +278,7 @@ def clear_foreign_config(node, raid_controller):
     :raises: DracOperationError on an error from python-dracclient.
     """
     try:
-
+        drac_job.wait_for_job_completion(node)
         drac_job.validate_job_queue(node)
 
         client = drac_common.get_drac_client(node)
@@ -678,7 +678,7 @@ def _assign_disks_to_volume(logical_disks, physical_disks_by_type,
         for disks_count in range(min_disks, candidate_max_disks + 1):
             if ('number_of_physical_disks' in logical_disk
                 and logical_disk['number_of_physical_disks'] != disks_count):
-                    continue
+                continue
 
             # skip invalid disks_count
             if disks_count != _usable_disks_count(logical_disk['raid_level'],


### PR DESCRIPTION
Hey @cdearborn ,
I have added call for wait_for_job_completion in ironic raid.py to resolve the bug regarding job completion status error occurred while executing clear_foreign_config substep via ironic cli.
I have tested code with the above changes , it was working fine.

I will update the unit test case in same PR , once this code changes is approved by you.