### PR TITLE
[WIP] added pxe_nic support for idrac-redfish

### DIFF
--- a/ironic/drivers/modules/drac/inspect.py
+++ b/ironic/drivers/modules/drac/inspect.py
@@ -15,9 +15,6 @@
 DRAC inspection interface
 """
 
-from datetime import datetime
-import json
-import re
 import xml.etree.ElementTree as et
 
 from ironic_lib import metrics_utils

--- a/ironic/tests/unit/drivers/modules/drac/test_inspect.py
+++ b/ironic/tests/unit/drivers/modules/drac/test_inspect.py
@@ -469,7 +469,6 @@ class DracRedfishInspectionTestCase(test_utils.BaseDracTest):
         system_mock.boot.mode = 'bios'
         export_configuration = {
             '_content': '<SystemConfiguration Model="PowerEdge R640" '
-                        'ServiceTag="DLMP4Z2" '
                         'TimeStamp="Thu Jan 23 09:27:07 2020">\n'
                         '<Component FQDD="NIC.Integrated.1-1-1">\n'
                         '<Attribute Name="LegacyBootProto">PXE</Attribute>\n'


### PR DESCRIPTION
Hi Chris,

I have raised PR for PXE_NIC support for redfish as per your request. 

also, I attached the manager.py(sushy_oem_idrac/resources/manager/manager.py) file. 

In manager.py file, I have written ``export_system_configuration`` method for exporting system configuration where we can specify the target and written property method for getting URI i.e ``export_system_configuration_uri`` 

[manager.zip](https://github.com/cdearborn/ironic/files/4139129/manager.zip) 

